### PR TITLE
Fix reticulate-anndata categoricals (HDF5.Group), AnnData Base.show i…

### DIFF
--- a/src/anndata.jl
+++ b/src/anndata.jl
@@ -228,7 +228,12 @@ Base.size(adata::AbstractAnnData, d::Integer) = size(adata)[d]
 
 function Base.show(io::IO, adata::AbstractAnnData)
     compact = get(io, :compact, false)
-    print(io, """$(typeof(adata).name.name) object $(size(adata)[1]) \u2715 $(size(adata)[2])""")
+    names_obs = names(adata.obs)
+    names_var = names(adata.var)
+    names_uns = adata.uns |> keys |> collect
+    names_layers = adata[:,:].layers |> keys |> collect
+    print(io, """$(typeof(adata).name.name) object with n_obs \u2715 n_var: $(size(adata)[1]) \u2715 $(size(adata)[2])\
+    \n   obs: $names_obs\n   var: $names_var\n   uns: $names_uns\n   layers: $names_layers""")
 end
 
 function Base.show(io::IO, ::MIME"text/plain", adata::AbstractAnnData)


### PR DESCRIPTION
## Changes in this PR
- Categorical handling by readh5ad()
- Dict handling by read_auto
- Base.show(::AnnData) functionality in line with python print()

### Categorical handling
A problem that I recently stumbled into is mishandling of categoricals of anndata objects. My anndata files were mostly created with reticulate, but I found the issue could also be reproduced with a minimal example without reticulate. (AnnData 0.8.0)

#### Minimal example
```
data = np.random.rand(10, 10)
obs = ["obs"+str(i) for i in range(0,10)]
var = ["var"+str(i) for i in range(0,10)]
obs = pd.DataFrame(data = {"Sex": pd.Categorical(["M","M","M","M","M","F","F","F","F","F"], categories=["M","F"])}, index = obs)
var = pd.DataFrame(data = {"ENSEMBL": ["ENSGMUS000"+str(i) for i in range(1,11)]}, index = var)
adata = sc.AnnData(data, obs, var)
adata.write_h5ad("/path/to/file.h5ad")
```

The categoricals of my datasets are classified as HDF5.Group in the anndata object, so the categorical column is not passed to this function as intended:

```
function read_matrix(f::HDF5.Dataset; kwargs...)
   (...)
    if haskey(attributes(f), "categories")
        (...)
    end
    return mat
end
```
But to this function, resulting in the error: `unknown encoding categorical`

```
function read_matrix(f::HDF5.Group; kwargs...)
    enctype = read_attribute(f, "encoding-type")

    if enctype == "csc_matrix" || enctype == "csr_matrix"
        (...)
    else
        error("unknown encoding $enctype")
    end
end
```

I created a dedicated read_column(::Union{HDF5.Group, HDF5.Dataset}) function for read_dataframe to call, which fixed the issue for my datasets as well as the minimal example. Furthermore, I commented near the `if haskey(attributes(f), "categories)` block in read_matrix as it may be redundant now that read_columns handles categoricals. Wasn't sure though, so I didn't want to remove it.

### Dict handling by read_auto
For nested dicts, the following issue arises:
Parent dict is passed to function read_dict_of_mixed
```
function read_dict_of_mixed(f::HDF5.Group; kwargs...)
    (...)
    for k in keys(f)
        ret[k] = read_auto(f[k]; kwargs...)[1] # assume data frames are properly aligned, so we can discard rownames
    end
    return ret
end
```

The child dict is then passed to read_auto
```
function read_auto(f::HDF5.Group; kwargs...)
    if haskey(attributes(f), "encoding-type")
        enctype = read_attribute(f, "encoding-type")
        if enctype == "dataframe"
            return read_dataframe(f; kwargs...)
        elseif endswith(enctype, "matrix")
            return read_matrix(f; kwargs), nothing
        else
            error("unknown encoding $enctype")
        end
    else
        return read_dict_of_mixed(f; kwargs...), nothing
    end
end
```
Which returns `unknown encoding dict`. This is easily fixed with `elseif enctype == "dict"; return read_dict_of_mixed(f; kwargs...)`

### Base.show 
I expanded Base.show(::AnnData) functionality to be in line with python AnnData.\_\_repr\_\_()