### PR TITLE
Anndata 0.8 compatibility

### DIFF
--- a/src/anndata.jl
+++ b/src/anndata.jl
@@ -190,7 +190,7 @@ end
 
 function Base.write(parent::Union{HDF5.File, HDF5.Group}, adata::AbstractAnnData)
     attrs = attributes(parent)
-    attrs["encoding-type"] = "AnnData"
+    attrs["encoding-type"] = "anndata"
     attrs["encoding-version"] = string(ANNDATAVERSION)
     attrs["encoder"] = NAME
     attrs["encoder-version"] = string(VERSION)

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 HDF5 = "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/test/elementwise_io.jl
+++ b/test/elementwise_io.jl
@@ -22,11 +22,15 @@ tmp = mktempdir()
     enc_tests = [
         ("hello world",      "string",         "0.2.0"),
         ([1,2,3],            "array",          "0.2.0"),
+        ([true,false,true],  "array",          "0.2.0"),
         (["hello", "world"], "string-array",   "0.2.0"),
         (1,                  "numeric-scalar", "0.2.0"),
         (1.0,                "numeric-scalar", "0.2.0"),
         (true,               "numeric-scalar", "0.2.0"),
         (Dict("a" => 1),     "dict",           "0.1.0"),
+        ([1,2,missing,3],           "nullable-integer", "0.1.0"),
+        ([true,false,missing,true], "nullable-boolean", "0.1.0"),
+        (BitVector([true,false,true]),           "array",       "0.2.0"),
         (CategoricalArray(["a", "b", "a", "a"]), "categorical", "0.2.0"),
         (CategoricalArray([1, 1, 2, 1]),         "categorical", "0.2.0"),
     ]
@@ -43,13 +47,16 @@ end
 
     outdata = Dict(
         "a" => [1,2,3],
-        "b" => [true, false, true],
+        "b" => BitVector([true, false, true]),
         "c" => ["a", "b", "c"],
         "d" => 1,
         "e" => true,
         "f" => "a",
         "g" => CategoricalArray(["a", "b", "a", "a"]),
-        "h" => CategoricalArray([1, 1, 2, 1]))
+        "h" => CategoricalArray([1, 1, 2, 1]),
+        "i" => [1,2,missing,3],
+        "k" => [true,false,missing,true]
+    )
 
     Muon.write_attr(g, "test", outdata)
     indata = Muon.read_dict_of_mixed(g["test"])
@@ -57,6 +64,25 @@ end
     @test keys(outdata) == keys(indata)
     for k in keys(outdata)
         @test typeof(outdata[k]) == typeof(indata[k])
-        @test outdata[k] == indata[k]
+
+        # special case to deal with missing
+        if isa(outdata[k], AbstractArray) && Missing <: eltype(outdata[k])
+            @test all(outdata[k] .=== indata[k])
+        else
+            @test outdata[k] == indata[k]
+        end
+    end
+
+    # Bool arrays don't survive round trip, but will be read as BitArrays
+    outdata = Dict(
+        "a" => [true, false, true, true]
+    )
+    Muon.write_attr(g, "test_bool", outdata)
+    indata = Muon.read_dict_of_mixed(g["test_bool"])
+
+    @test keys(outdata) == keys(indata)
+    for k in keys(outdata)
+        @test eltype(outdata[k]) == eltype(indata[k])
+        @test all(outdata[k] .=== indata[k])
     end
 end

--- a/test/elementwise_io.jl
+++ b/test/elementwise_io.jl
@@ -1,0 +1,62 @@
+
+
+using CategoricalArrays
+using HDF5
+
+tmp = mktempdir()
+
+@testset "encoding_types" begin
+    tempfile1 = joinpath(tmp, "tmp_encoding_types.h5ad")
+    output = h5open(tempfile1, "w")
+    g = create_group(output, "test")
+
+    function test_encoding(data, expected_type, expected_version)
+        Muon.write_attr(g, "test", data)
+        attrs = attributes(g["test"])
+        @test haskey(attrs, "encoding-type")
+        @test read(attrs["encoding-type"]) == expected_type
+        @test haskey(attrs, "encoding-version")
+        @test read(attrs["encoding-version"]) == expected_version
+    end
+
+    enc_tests = [
+        ("hello world",      "string",         "0.2.0"),
+        ([1,2,3],            "array",          "0.2.0"),
+        (["hello", "world"], "string-array",   "0.2.0"),
+        (1,                  "numeric-scalar", "0.2.0"),
+        (1.0,                "numeric-scalar", "0.2.0"),
+        (true,               "numeric-scalar", "0.2.0"),
+        (Dict("a" => 1),     "dict",           "0.1.0"),
+        (CategoricalArray(["a", "b", "a", "a"]), "categorical", "0.2.0"),
+        (CategoricalArray([1, 1, 2, 1]),         "categorical", "0.2.0"),
+    ]
+
+    for args in enc_tests
+        test_encoding(args...)
+    end
+end
+
+@testset "roundtrip" begin
+    tempfile1 = joinpath(tmp, "tmp_roundtrip.h5ad")
+    output = h5open(tempfile1, "w")
+    g = create_group(output, "test")
+
+    outdata = Dict(
+        "a" => [1,2,3],
+        "b" => [true, false, true],
+        "c" => ["a", "b", "c"],
+        "d" => 1,
+        "e" => true,
+        "f" => "a",
+        "g" => CategoricalArray(["a", "b", "a", "a"]),
+        "h" => CategoricalArray([1, 1, 2, 1]))
+
+    Muon.write_attr(g, "test", outdata)
+    indata = Muon.read_dict_of_mixed(g["test"])
+
+    @test keys(outdata) == keys(indata)
+    for k in keys(outdata)
+        @test typeof(outdata[k]) == typeof(indata[k])
+        @test outdata[k] == indata[k]
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,9 @@ using Muon, Test
 @testset "Index" begin
     include("index.jl")
 end
+@testset "Elementwise IO" begin
+    include("elementwise_io.jl")
+end
 @testset "HDF5 backed matrix" begin
     include("backed_matrix.jl")
 end


### PR DESCRIPTION
This could probably use some more tests, but I think this PR largely makes Muon.jl compatible with anndata 0.8. (Fixes #15)

Main changes are:
  * Implement `categorical` using `CategoricalArrays`
  * Read/write bools as an enum, like anndata does. Bool arrays are read as `BitArrays`.
  * Add `encoding-type`, `encoding-version` attributes in various places.
  * Implement `nullable-integer`, `nullable-boolean` using `Union{T, Missing}` arrays. (I considered `SentinelArrays`, but these aren't compatible with Bool.
