### PR TITLE
Index: Fix integer bit size calculation

### DIFF
--- a/src/index.jl
+++ b/src/index.jl
@@ -13,7 +13,7 @@ mutable struct Index{T, V} <: AbstractIndex{T, V}
     function Index{T}(nelements::Integer) where {T}
         size = ceil(nelements / 0.9) # 0.9 load factor
 
-        mintype = minimum_unsigned_type_for_n(nelements)
+        mintype = minimum_unsigned_type_for_n(size)
         return new{T, mintype}(
             Vector{T}(undef, nelements),
             zeros(mintype, mintype(size)),


### PR DESCRIPTION
Hello,

While working with Muon.jl to create AnnData objects, I hit a bug which is caused by calculating the minimal required bitsize on the wrong number it seems. I think my changes in this PR now calculate the mintype correctly and which fixes the bug.

This MWE hits the bug:

```julia
using Muon

a = Array{Int64}(undef, (typemax(UInt16), 100))
ad = AnnData(X=a) # throws an InexactError: UInt16(72817.0)
```