### PR TITLE
Fix reading boolean matrices.

### DIFF
--- a/src/hdf5_io.jl
+++ b/src/hdf5_io.jl
@@ -24,12 +24,12 @@ end
 function read_matrix(f::HDF5.Dataset; kwargs...)
     mat = read(f)
 
-    if datatype(f) == _datatype(Bool)
-        return BitArray(mat)
-    end
-
     if HDF5.API.h5t_get_class(datatype(f)) == HDF5.API.H5T_COMPOUND
         return StructArray(mat)
+    end
+
+    if datatype(f) == _datatype(Bool)
+        mat = BitArray(mat)
     end
 
     if ndims(f) == 0

--- a/test/elementwise_io.jl
+++ b/test/elementwise_io.jl
@@ -30,7 +30,8 @@ tmp = mktempdir()
         (Dict("a" => 1),     "dict",           "0.1.0"),
         ([1,2,missing,3],           "nullable-integer", "0.1.0"),
         ([true,false,missing,true], "nullable-boolean", "0.1.0"),
-        (BitVector([true,false,true]),           "array",       "0.2.0"),
+        (BitVector([true,false,true]),                  "array",       "0.2.0"),
+        (BitMatrix([true false true;false true false]), "array",       "0.2.0"),
         (CategoricalArray(["a", "b", "a", "a"]), "categorical", "0.2.0"),
         (CategoricalArray([1, 1, 2, 1]),         "categorical", "0.2.0"),
     ]


### PR DESCRIPTION
Fixes a bug with how boolean matrices are read. Previously they didn't get properly wrapped in a `PermutedDimsArray`.