### PR TITLE
Dont default to backed in readh5ad and read5mu

### DIFF
--- a/src/anndata.jl
+++ b/src/anndata.jl
@@ -21,7 +21,7 @@ mutable struct AnnData <: AbstractAnnData
 
     uns::Dict{<:AbstractString, <:Any}
 
-    function AnnData(file::Union{HDF5.File, HDF5.Group}, backed=true, checkversion=true)
+    function AnnData(file::Union{HDF5.File, HDF5.Group}, backed=false, checkversion=true)
         if checkversion
             attrs = attributes(file)
             if !haskey(attrs, "encoding-type")
@@ -138,7 +138,7 @@ end
 
 file(ad::AnnData) = ad.file
 
-function readh5ad(filename::AbstractString; backed=true)
+function readh5ad(filename::AbstractString; backed=false)
     filename = abspath(filename) # this gets stored in the HDF5 objects for backed datasets
     if !backed
         fid = h5open(filename, "r")

--- a/src/mudata.jl
+++ b/src/mudata.jl
@@ -18,7 +18,7 @@ mutable struct MuData <: AbstractMuData
 
     uns::Dict{<:AbstractString, <:Any}
 
-    function MuData(file::Union{HDF5.File, HDF5.Group}, backed=true, checkversion=true)
+    function MuData(file::Union{HDF5.File, HDF5.Group}, backed=false, checkversion=true)
         if checkversion
             attrs = attributes(file)
             if !haskey(attrs, "encoding-type")
@@ -141,7 +141,7 @@ end
 
 file(mu::MuData) = mu.file
 
-function readh5mu(filename::AbstractString; backed=true)
+function readh5mu(filename::AbstractString; backed=false)
     filename = abspath(filename) # this gets stored in the HDF5 objects for backed datasets
     if String(read(filename, 6)) != "MuData"
         if HDF5.ishdf5(filename)


### PR DESCRIPTION
This is not a bug-fix, but more of a design decision I'd like to broach. I think reading should default to non-backed for a couple of reasons:

This is what the anndata python package does, so there's a consistency argument. But more concretely, backed AnnData objects have some peculiarities that surprised me at first, so I'd assume would come as a surprise to others. First, some operations are much slower on backed matrices. A more subtle gotcha, is that opening an h5ad backed updates its timestamp, whether anything is modified or not. This can screw up workflow managers (e.g. snakemake), causing them to repeatedly rerun things.

Ultimately, it seems to me better to make this a non-default feature, useful for special handling of particularly large files.