### PR TITLE
Add DataFrame constructor for AnnData

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,3 +1,4 @@
 [deps]
+DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,4 +1,4 @@
-using Documenter, Muon
+using Documenter, Muon, DataFrames
 
 makedocs(sitename="Muon Documentation", warnonly=:cross_references)
 

--- a/docs/src/objects.md
+++ b/docs/src/objects.md
@@ -76,6 +76,21 @@ import Muon: obs_names_make_unique! # hide
 obs_names_make_unique!(ad)
 ```
 
+The data matrices of `AnnData` objects can be converted to a `DataFrame`, annotated with `obs` and `var` names.
+
+```@example 1
+using DataFrames
+DataFrame(ad)
+```
+
+By default, the first column `obs` corresponds to the `obs_names` and the remaining columns are named according to the `var_names`. To obtain the transpose of this, pass `columns=:obs`.
+
+To use a different data matrix (the default is `ad.X`), pass the name of the layer:
+
+```julia
+DataFrame(ad, layer="raw")
+```
+
 ## MuData
 
 The basic idea behind a multimodal object is _key_ ``\rightarrow`` _value_ relationship where _keys_ represent the unique names of individual modalities and _values_ are `AnnData` objects that contain the correposnding data. Similarly to `AnnData` objects, `MuData` objects can also contain rich multimodal annotations.

--- a/test/anndata.jl
+++ b/test/anndata.jl
@@ -61,3 +61,17 @@ end
     @test allunique(ad2.var_names)
     @test allunique(ad2.obs_names)
 end
+
+@testset "DataFrame conversion" begin
+    using DataFrames
+    df = DataFrame(ad)
+    @test names(df) == ["obs"; ad.var_names]
+    @test df.obs == ad.obs_names
+    ad.var_names[3] = "10"
+    @test_throws ArgumentError DataFrame(ad)
+    @test_throws ArgumentError DataFrame(ad, columns=:foo)
+    @test_throws ArgumentError DataFrame(ad, layer="doesn't exist")
+    df2 = DataFrame(ad, columns=:obs)
+    @test names(df2) == ["var"; ad.obs_names]
+    @test df2.var == ad.var_names
+end


### PR DESCRIPTION
Similar to Python AnnData `ad.to_df(layer="layername")`.
Also allows returning a DataFrame in the Seurat orientation with `columns=:obs`.

Partially addresses #8 